### PR TITLE
fix error if pyramid_extdirect.json_encoder is not set

### DIFF
--- a/pyramid_extdirect/__init__.py
+++ b/pyramid_extdirect/__init__.py
@@ -416,7 +416,7 @@ def includeme(config):
         value = settings.get(qname, None)
         if name == "expose_exceptions" or name == "debug_mode":
             value = (value == "true")
-        if name == "json_encoder":
+        if name == "json_encoder" and value:
             from pyramid.path import DottedNameResolver
             resolver = DottedNameResolver()
             value = resolver.resolve(value)


### PR DESCRIPTION
If pyramid_extdirect.json_encoder is not set, the following ValueError is raised:

>   File "/local/lib/python2.7/site-packages/pyramid-1.6.1-py2.7.egg/pyramid/config/__init__.py", line 798, in include
    c(configurator)
  File "/local/lib/python2.7/site-packages/pyramid_extdirect-0.5.1-py2.7.egg/pyramid_extdirect/__init__.py", line 422, in includeme
    value = resolver.resolve(value)
  File "/local/lib/python2.7/site-packages/pyramid-1.6.1-py2.7.egg/pyramid/path.py", line 296, in resolve
    raise ValueError('%r is not a string' % (dotted,))
ValueError: None is not a string

This can be fixed with checking if value is set.