### PR TITLE
docs: Fix simple typo, respresentation -> representation

### DIFF
--- a/pyramid_extdirect/__init__.py
+++ b/pyramid_extdirect/__init__.py
@@ -74,7 +74,7 @@ class AccessDeniedException(Exception):
 @implementer(IExtdirect)
 class Extdirect(object):
     """
-    Handles ExtDirect API respresentation and routing.
+    Handles ExtDirect API representation and routing.
 
     The Extdirect accepts a number of arguments: ``app``,
     ``api_path``, ``router_path``, ``namespace``, ``descriptor``


### PR DESCRIPTION
There is a small typo in pyramid_extdirect/__init__.py.

Should read `representation` rather than `respresentation`.

